### PR TITLE
Change error message so that IntelliJ can show <Click to see difference> link

### DIFF
--- a/src/main/java/io/github/orangain/jsonmatch/JsonMatch.java
+++ b/src/main/java/io/github/orangain/jsonmatch/JsonMatch.java
@@ -12,7 +12,7 @@ public class JsonMatch {
     public static void assertJsonMatches(String actualJson, String patternJson) {
         Optional<String> errorMessage = jsonMatches(actualJson, patternJson);
         if (errorMessage.isPresent()) {
-            throw new AssertionError(String.format("%nExpecting:%n %s%nto match pattern:%n %s%n%s", actualJson, patternJson, errorMessage.get()));
+            throw new AssertionError(errorMessage.get());
         }
     }
 
@@ -34,6 +34,6 @@ public class JsonMatch {
 
         JsonPatternNode rootPattern = JsonMatchPatternParser.parse(patternTree);
         Optional<JsonMatchError> error = rootPattern.matches(JsonPath.ROOT, actualTree);
-        return error.map(JsonMatchError::toString);
+        return error.map(errorMessage -> String.format("%s%nexpected:<%s> but was:<%s>", errorMessage, patternTree.toPrettyString(), actualTree.toPrettyString()));
     }
 }

--- a/src/main/java/io/github/orangain/jsonmatch/JsonMatch.java
+++ b/src/main/java/io/github/orangain/jsonmatch/JsonMatch.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 public class JsonMatch {
     public static void assertJsonMatches(String actualJson, String patternJson) {
         Optional<String> errorMessage = jsonMatches(actualJson, patternJson);
-        if (errorMessage.isPresent()) {
-            throw new AssertionError(errorMessage.get());
-        }
+        errorMessage.ifPresent(m -> {
+            throw new AssertionError(m);
+        });
     }
 
     public static Optional<String> jsonMatches(String actualJson, String patternJson) {

--- a/src/main/java/io/github/orangain/jsonmatch/JsonStringAssert.java
+++ b/src/main/java/io/github/orangain/jsonmatch/JsonStringAssert.java
@@ -19,7 +19,7 @@ public class JsonStringAssert extends AbstractAssert<JsonStringAssert, String> {
         isNotNull();
 
         Optional<String> errorMessage = JsonMatch.jsonMatches(actual, patternJson);
-        errorMessage.ifPresent(m -> failWithMessage("%nExpecting:%n %s%nto match pattern:%n %s%n%s", actual, patternJson, m));
+        errorMessage.ifPresent(m -> failWithMessage(m));
 
         return this;
     }

--- a/src/test/kotlin/io/github/orangain/jsonmatch/AssertionTest.kt
+++ b/src/test/kotlin/io/github/orangain/jsonmatch/AssertionTest.kt
@@ -19,13 +19,14 @@ class AssertionTest {
         assertThatThrownBy {
             JsonMatch.assertJsonMatches("""{"foo": "bar"}""", """{ "foo": "#null" }""")
         }.isInstanceOf(AssertionError::class.java).hasMessage(
-            "\n" + """
-            Expecting:
-             {"foo": "bar"}
-            to match pattern:
-             { "foo": "#null" }
-            path: $.foo, actual: "bar", expected: "#null", reason: not-null
-        """.trimIndent()
+            """
+                path: $.foo, actual: "bar", expected: "#null", reason: not-null
+                expected:<{
+                  "foo" : "#null"
+                }> but was:<{
+                  "foo" : "bar"
+                }>
+            """.trimIndent()
         )
     }
 
@@ -41,13 +42,14 @@ class AssertionTest {
         assertThatThrownBy {
             JsonStringAssert.assertThat("""{"foo": "bar"}""").jsonMatches("""{ "foo": "#null" }""")
         }.isInstanceOf(AssertionError::class.java).hasMessage(
-            "\n" + """
-            Expecting:
-             {"foo": "bar"}
-            to match pattern:
-             { "foo": "#null" }
-            path: $.foo, actual: "bar", expected: "#null", reason: not-null
-        """.trimIndent()
+            """
+                path: $.foo, actual: "bar", expected: "#null", reason: not-null
+                expected:<{
+                  "foo" : "#null"
+                }> but was:<{
+                  "foo" : "bar"
+                }>
+            """.trimIndent()
         )
     }
 }


### PR DESCRIPTION
Now, both actual and pattern JSON is pretty-formatted in the error message.

![image](https://user-images.githubusercontent.com/532251/88254708-0fa6dd80-ccf1-11ea-87c9-965b74787780.png)
