### PR TITLE
Move to JitPack

### DIFF
--- a/.idea/json-fuzzy-match.iml
+++ b/.idea/json-fuzzy-match.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="json-fuzzy-match:main" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="io.github.orangain.json-fuzzy-match" external.system.module.version="0.4.0" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/json-fuzzy-match.iml" filepath="$PROJECT_DIR$/.idea/json-fuzzy-match.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -9,5 +9,10 @@
       </set>
     </option>
     <option name="configurationPath" value="" />
+    <option name="exclusions">
+      <set>
+        <option value=".*\.md" />
+      </set>
+    </option>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # json-fuzzy-match [![JitPack](https://jitpack.io/v/orangain/json-fuzzy-match.svg)](https://jitpack.io/#orangain/json-fuzzy-match) [![Java CI](https://github.com/orangain/json-fuzzy-match/workflows/Java%20CI/badge.svg)](https://github.com/orangain/json-fuzzy-match/actions?query=workflow%3A%22Java+CI%22)
 
-json-fuzzy-match provides assertion to check whether a JSON string fuzzily matches a pattern for JVM languages. This is
-useful when you test JSON response including dynamic or generated value.
+json-fuzzy-match provides assertion to check whether a JSON string fuzzily matches a pattern for JVM languages.
+This is useful when you test JSON response including dynamic or generated value.
 
 For example, think about testing the following JSON response.
 
 ```json5
 {
-  "id": "2c0a9fd7-be2c-4bc2-b134-acc3fa13d400",
-  // Generated UUID
-  "title": "Example Book",
-  "price": "9.99",
-  "currency": "USD",
-  "amount": 10,
-  "timestamp": "2019-09-25T13:34:17Z"
-  // Dynamic timestamp
+    "id": "2c0a9fd7-be2c-4bc2-b134-acc3fa13d400", // Generated UUID
+    "title": "Example Book",
+    "price": "9.99",
+    "currency": "USD",
+    "amount": 10,
+    "timestamp": "2019-09-25T13:34:17Z" // Dynamic timestamp
 }
 ```
 
@@ -46,8 +44,8 @@ JsonStringAssert.assertThat(response.content).jsonMatches("""
 """.trimIndent())
 ```
 
-It is recommended to use json-fuzzy-match with languages which have multi-line string literal such as Kotlin, Scala and
-Groovy. Sample codes in this README are written in Kotlin.
+It is recommended to use json-fuzzy-match with languages which have multi-line string literal such as Kotlin, Scala, Java 13+ and Groovy.
+Sample codes in this README are written in Kotlin.
 
 ## Install
 
@@ -59,41 +57,34 @@ json-fuzzy-match is available on [JitPack](https://jitpack.io/#orangain/json-fuz
 repositories {
   maven { setUrl("https://jitpack.io") }
 }
-```
 
-```kts
 dependencies {
-  testImplementation("com.github.orangain:json-fuzzy-match:0.4.0")
+  testImplementation("com.github.orangain:json-fuzzy-match:0.4.1")
 }
 ```
 
 ### Maven
 
 ```xml
-
 <repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
+  <repository>
+    <id>jitpack.io</id>
+    <url>https://jitpack.io</url>
+  </repository>
 </repositories>
-```
-
-```xml
 
 <dependencies>
-    <dependency>
-        <groupId>com.github.orangain</groupId>
-        <artifactId>json-fuzzy-match</artifactId>
-        <version>0.4.0</version>
-    </dependency>
+  <dependency>
+    <groupId>com.github.orangain</groupId>
+    <artifactId>json-fuzzy-match</artifactId>
+    <version>0.4.1</version>
+  </dependency>
 </dependencies>
 ```
 
 ## Usage
 
-json-fuzzy-match provides both [AssertJ](https://joel-costigliola.github.io/assertj/)-style
-and [JUnit](https://junit.org/junit5/)-style assertions.
+json-fuzzy-match provides both [AssertJ](https://joel-costigliola.github.io/assertj/)-style and [JUnit](https://junit.org/junit5/)-style assertions.
 
 ```kt
 // AssertJ-style
@@ -109,8 +100,9 @@ import io.github.orangain.jsonmatch.JsonMatch.assertJsonMatches
 assertJsonMatches("""{ "foo": "bar" }""", """{ "foo": "#notnull" }""")
 ```
 
-In the above examples, the second argument `patternJson` contains `#notnull` marker. The assertion means that value
-of `foo` field must exist and not null. There are several markers as followings:
+In the above examples, the second argument `patternJson` contains `#notnull` marker.
+The assertion means that value of `foo` field must exist and not null.
+There are several markers as followings:
 
 Marker | Description
 ------ | -----------
@@ -157,12 +149,11 @@ Pattern                  | `{}`                     | `{ "a": null }`          |
 * `{ "id": "123" }` does not match the pattern `{ "id": "#regex [a-z]+" }`
 
 #### Advanced array marker
-
 * `{ "tags": ["awesome", "shop"] }` matches the following patterns:
-    * `{ "tags": "#[]" }`
-    * `{ "tags": "#[2]" }`
-    * `{ "tags": "#[] #string" }`
-    * `{ "tags": "#[2] #string" }`
+  * `{ "tags": "#[]" }`
+  * `{ "tags": "#[2]" }`
+  * `{ "tags": "#[] #string" }`
+  * `{ "tags": "#[2] #string" }`
 
 ## License
 
@@ -170,10 +161,7 @@ MIT License. See `LICENSE`.
 
 ## Acknowledgement
 
-I'm very grateful for the [Karate](https://intuit.github.io/karate/) and its authors. The idea of the marker is heavily
-inspired by the Karate's wonderful fuzzy matching feature. Though json-fuzzy-match does not depend on Karate now, the
-first version of this library only provided a thin wrapper of Karate's feature. Without it, I was not able to develop
-this library so quickly.
-
-
-
+I'm very grateful for the [Karate](https://intuit.github.io/karate/) and its authors.
+The idea of the marker is heavily inspired by the Karate's wonderful fuzzy matching feature.
+Though json-fuzzy-match does not depend on Karate now, the first version of this library only provided a thin wrapper of Karate's feature.
+Without it, I was not able to develop this library so quickly.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-# json-fuzzy-match [![](https://img.shields.io/bintray/v/orangain/maven/json-fuzzy-match)](https://bintray.com/orangain/maven/json-fuzzy-match) [![Java CI](https://github.com/orangain/json-fuzzy-match/workflows/Java%20CI/badge.svg)](https://github.com/orangain/json-fuzzy-match/actions?query=workflow%3A%22Java+CI%22)
+# json-fuzzy-match [![JitPack](https://jitpack.io/v/orangain/json-fuzzy-match.svg)](https://jitpack.io/#orangain/json-fuzzy-match) [![Java CI](https://github.com/orangain/json-fuzzy-match/workflows/Java%20CI/badge.svg)](https://github.com/orangain/json-fuzzy-match/actions?query=workflow%3A%22Java+CI%22)
 
-json-fuzzy-match provides assertion to check whether a JSON string fuzzily matches a pattern for JVM languages.
-This is useful when you test JSON response including dynamic or generated value. 
+json-fuzzy-match provides assertion to check whether a JSON string fuzzily matches a pattern for JVM languages. This is
+useful when you test JSON response including dynamic or generated value.
 
 For example, think about testing the following JSON response.
 
 ```json5
 {
-    "id": "2c0a9fd7-be2c-4bc2-b134-acc3fa13d400", // Generated UUID
-    "title": "Example Book",
-    "price": "9.99",
-    "currency": "USD",
-    "amount": 10,
-    "timestamp": "2019-09-25T13:34:17Z" // Dynamic timestamp
+  "id": "2c0a9fd7-be2c-4bc2-b134-acc3fa13d400",
+  // Generated UUID
+  "title": "Example Book",
+  "price": "9.99",
+  "currency": "USD",
+  "amount": 10,
+  "timestamp": "2019-09-25T13:34:17Z"
+  // Dynamic timestamp
 }
 ```
 
@@ -44,48 +46,54 @@ JsonStringAssert.assertThat(response.content).jsonMatches("""
 """.trimIndent())
 ```
 
-It is recommended to use json-fuzzy-match with languages which have multi-line string literal such as Kotlin, Scala and Groovy.
-Sample codes in this README are written in Kotlin.
-
+It is recommended to use json-fuzzy-match with languages which have multi-line string literal such as Kotlin, Scala and
+Groovy. Sample codes in this README are written in Kotlin.
 
 ## Install
 
-json-fuzzy-match is available on [jCenter](https://bintray.com/orangain/maven/json-fuzzy-match). 
+json-fuzzy-match is available on [JitPack](https://jitpack.io/#orangain/json-fuzzy-match).
 
-### Gradle (both Kotlin and Groovy DSL)
+### Gradle Kotlin DSL
 
 ```kts
 repositories {
-  jcenter()
+  maven { setUrl("https://jitpack.io") }
 }
+```
 
+```kts
 dependencies {
-  testImplementation("io.github.orangain.json-fuzzy-match:json-fuzzy-match:0.4.0")
+  testImplementation("com.github.orangain:json-fuzzy-match:0.4.0")
 }
 ```
 
 ### Maven
 
 ```xml
+
 <repositories>
-  <repository>
-    <id>jcenter</id>
-    <url>https://jcenter.bintray.com/</url>
-  </repository>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
 </repositories>
+```
+
+```xml
 
 <dependencies>
-  <dependency>
-    <groupId>io.github.orangain.json-fuzzy-match</groupId>
-    <artifactId>json-fuzzy-match</artifactId>
-    <version>0.4.0</version>
-  </dependency>
+    <dependency>
+        <groupId>com.github.orangain</groupId>
+        <artifactId>json-fuzzy-match</artifactId>
+        <version>0.4.0</version>
+    </dependency>
 </dependencies>
 ```
 
 ## Usage
 
-json-fuzzy-match provides both [AssertJ](https://joel-costigliola.github.io/assertj/)-style and [JUnit](https://junit.org/junit5/)-style assertions.
+json-fuzzy-match provides both [AssertJ](https://joel-costigliola.github.io/assertj/)-style
+and [JUnit](https://junit.org/junit5/)-style assertions.
 
 ```kt
 // AssertJ-style
@@ -101,9 +109,8 @@ import io.github.orangain.jsonmatch.JsonMatch.assertJsonMatches
 assertJsonMatches("""{ "foo": "bar" }""", """{ "foo": "#notnull" }""")
 ```
 
-In the above examples, the second argument `patternJson` contains `#notnull` marker.
-The assertion means that value of `foo` field must exist and not null.
-There are several markers as followings:
+In the above examples, the second argument `patternJson` contains `#notnull` marker. The assertion means that value
+of `foo` field must exist and not null. There are several markers as followings:
 
 Marker | Description
 ------ | -----------
@@ -135,45 +142,38 @@ Pattern                  | `{}`                     | `{ "a": null }`          |
 
 #### Date marker
 
-* `{ "createdOn": "2020-07-23" }` matches the pattern `{ "createdOn": "#date" }` 
-* `{ "createdOn": "2020/07/23" }` does not match the pattern `{ "createdOn": "#date" }` 
+* `{ "createdOn": "2020-07-23" }` matches the pattern `{ "createdOn": "#date" }`
+* `{ "createdOn": "2020/07/23" }` does not match the pattern `{ "createdOn": "#date" }`
 
 #### Datetime marker
 
-* `{ "createdAt": "2020-07-23T14:56:11+09:00" }` matches the pattern `{ "createdAt": "#datetime" }` 
-* `{ "createdAt": "2020-07-23T05:56:11Z" }` matches the pattern `{ "createdAt": "#datetime" }` 
-* `{ "createdAt": "2020-07-23T05:56:11" }` does not match the pattern `{ "createdAt": "#datetime" }` 
+* `{ "createdAt": "2020-07-23T14:56:11+09:00" }` matches the pattern `{ "createdAt": "#datetime" }`
+* `{ "createdAt": "2020-07-23T05:56:11Z" }` matches the pattern `{ "createdAt": "#datetime" }`
+* `{ "createdAt": "2020-07-23T05:56:11" }` does not match the pattern `{ "createdAt": "#datetime" }`
 
 #### Regex marker
 
-* `{ "id": "abc" }` matches the pattern `{ "id": "#regex [a-z]+" }` 
-* `{ "id": "123" }` does not match the pattern `{ "id": "#regex [a-z]+" }` 
+* `{ "id": "abc" }` matches the pattern `{ "id": "#regex [a-z]+" }`
+* `{ "id": "123" }` does not match the pattern `{ "id": "#regex [a-z]+" }`
 
 #### Advanced array marker
+
 * `{ "tags": ["awesome", "shop"] }` matches the following patterns:
-  * `{ "tags": "#[]" }`
-  * `{ "tags": "#[2]" }`
-  * `{ "tags": "#[] #string" }`
-  * `{ "tags": "#[2] #string" }`
-
-## Development
-
-Release an artifact to Bintray. Then publish it from [Web console](https://bintray.com/orangain/maven/json-fuzzy-match).
-
-```
-./gradlew bintrayUpload
-```
+    * `{ "tags": "#[]" }`
+    * `{ "tags": "#[2]" }`
+    * `{ "tags": "#[] #string" }`
+    * `{ "tags": "#[2] #string" }`
 
 ## License
 
 MIT License. See `LICENSE`.
 
-## Acknowledgement 
+## Acknowledgement
 
-I'm very grateful for the [Karate](https://intuit.github.io/karate/) and its authors.
-The idea of the marker is heavily inspired by the Karate's wonderful fuzzy matching feature.
-Though json-fuzzy-match does not depend on Karate now, the first version of this library only provided a thin wrapper of Karate's feature.
-Without it, I was not able to develop this library so quickly.
+I'm very grateful for the [Karate](https://intuit.github.io/karate/) and its authors. The idea of the marker is heavily
+inspired by the Karate's wonderful fuzzy matching feature. Though json-fuzzy-match does not depend on Karate now, the
+first version of this library only provided a thin wrapper of Karate's feature. Without it, I was not able to develop
+this library so quickly.
 
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     `java-library`
     `maven-publish`
     kotlin("jvm") version "1.3.50"
-    id("com.jfrog.bintray") version "1.8.4"
 }
 
 group = "io.github.orangain.json-fuzzy-match"
@@ -38,58 +37,4 @@ val sourcesJar by tasks.registering(Jar::class) {
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")
     from(tasks.javadoc)
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("maven") {
-            from(components["java"])
-            artifact(sourcesJar.get())
-            artifact(javadocJar.get())
-            groupId = project.group as String
-            artifactId = project.name
-            version = project.version as String
-            pom {
-                name.set(project.name)
-                description.set("Custom assertion to check JSON string matches pattern.")
-                url.set("https://github.com/orangain/json-fuzzy-match")
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://github.com/orangain/json-fuzzy-match/blob/master/LICENSE")
-                        distribution.set("repo")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("orangain")
-                        name.set("Kota Kato")
-                        email.set("orangain@gmail.com")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/orangain/json-fuzzy-match")
-                }
-            }
-        }
-    }
-}
-
-bintray {
-    val bintrayUser: String? by project
-    val bintrayAPIKey: String? by project
-    user = bintrayUser
-    key = bintrayAPIKey
-    setPublications("maven")
-    with(pkg) {
-        repo = "maven"
-        name = "json-fuzzy-match"
-        with(version) {
-            name = project.version as String
-        }
-    }
-}
-
-tasks.bintrayUpload {
-    dependsOn(tasks.build)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     kotlin("jvm") version "1.3.50"
 }
 
-group = "io.github.orangain.json-fuzzy-match"
-version = "0.4.0"
+group = "com.github.orangain"
+version = "0.4.1"
 
 repositories {
     mavenCentral()
@@ -18,7 +18,7 @@ dependencies {
     implementation("org.assertj:assertj-core:3.11.1")
     implementation("org.jetbrains:annotations:13.0")
     testImplementation(kotlin("stdlib-jdk8"))
-    testImplementation("junit", "junit", "4.12")
+    testImplementation("junit:junit:4.12")
     testImplementation("org.assertj:assertj-core:3.11.1")
 }
 


### PR DESCRIPTION
Because of [the service end of jCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), we are moving to [JitPack](https://jitpack.io/#orangain/json-fuzzy-match). Now groupId of the package is renamed to `com.github.orangain` according to the JitPack's naming rule.

Thank you jCenter for now!